### PR TITLE
Refactor the friend request/response

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,6 +3,7 @@ import {
 	type LucideProps,
 	BookHeart,
 	ChevronLeft,
+	Contact,
 	FolderPlus,
 	Handshake,
 	Home,
@@ -75,7 +76,7 @@ export default function Navbar() {
 						{data?.contextMenu.map(({ to, params, name, icon }, index) => (
 							<DropdownMenuItem key={index}>
 								<Link
-									to={to}
+									to={to as string}
 									params={params}
 									className="w-full flex flex-row gap-2 justify-content-center"
 								>
@@ -104,6 +105,8 @@ function renderIcon(icon: string, props: LucideProps = { size: 20 }) {
 			return <Mail {...props} />
 		case 'folder-plus': // for a new deck
 			return <FolderPlus {...props} />
+		case 'friend':
+			return <Contact {...props} />
 		case 'handshake':
 			return <Handshake {...props} />
 		case 'home': // for your /learn page

--- a/src/components/profile-with-relationship.tsx
+++ b/src/components/profile-with-relationship.tsx
@@ -8,6 +8,16 @@ import { AvatarIconRow } from '@/components/ui/avatar-icon'
 import supabase from '@/lib/supabase-client'
 import { useAuth } from '@/lib/hooks'
 import { Tables } from '@/types/supabase'
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from './ui/dialog'
 
 export function ProfileWithRelationship({
 	otherPerson,
@@ -42,6 +52,9 @@ export function ProfileWithRelationship({
 			if (variable === 'remove') toast('You are no longer friends')
 			void queryClient.invalidateQueries({
 				queryKey: ['user', 'friends', 'summaries'],
+			})
+			void queryClient.invalidateQueries({
+				queryKey: ['public_profile', 'search'],
 			})
 		},
 		onError: (error, variables) => {
@@ -105,15 +118,42 @@ export function ProfileWithRelationship({
 					relationship?.status === 'pending' &&
 					userId === relationship?.most_recent_uid_by
 				) ?
-					<Button
-						variant="secondary"
-						className="w-8 h-8"
-						size="icon"
-						title="Cancel friend request"
-						onClick={() => inviteResponseMutation.mutate('cancel')}
-					>
-						<X className="w-6 h-6 p-0" />
-					</Button>
+					<Dialog>
+						<DialogTrigger asChild>
+							<Button
+								variant="secondary"
+								className="w-8 h-8"
+								size="icon"
+								title="Cancel friend request"
+							>
+								<X className="w-6 h-6 p-0" />
+							</Button>
+						</DialogTrigger>
+						<DialogContent className="sm:max-w-[425px]">
+							<DialogHeader>
+								<DialogTitle>Cancel this invitation</DialogTitle>
+								<DialogDescription>
+									Please confirm whether you'd like to cancel this invitation
+								</DialogDescription>
+							</DialogHeader>
+							<DialogFooter className="justify-between">
+								<DialogClose asChild>
+									<Button variant="secondary">Go back</Button>
+								</DialogClose>
+								<Button
+									variant="destructive"
+									title="Confirm: Cancel friend request"
+									onClick={() => inviteResponseMutation.mutate('cancel')}
+								>
+									{inviteResponseMutation.isPending ?
+										<Loader2 />
+									: inviteResponseMutation.isSuccess ?
+										<Check className="text-white w-6 h-6" />
+									:	<>Confirm</>}
+								</Button>
+							</DialogFooter>
+						</DialogContent>
+					</Dialog>
 				: relationship.status === 'friends' ?
 					<Handshake className="w-6 h-6 p-0" />
 				:	<> status is null for some reason</>}

--- a/src/components/profile-with-relationship.tsx
+++ b/src/components/profile-with-relationship.tsx
@@ -1,17 +1,20 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
-import { Check, Loader2, Send, ThumbsUp, X } from 'lucide-react'
+import { Check, Handshake, Loader2, Send, ThumbsUp, X } from 'lucide-react'
 
 import type { PublicProfileFull, FriendRequestActionInsert } from '@/types/main'
 import { Button } from '@/components/ui/button'
 import { AvatarIconRow } from '@/components/ui/avatar-icon'
 import supabase from '@/lib/supabase-client'
 import { useAuth } from '@/lib/hooks'
+import { Tables } from '@/types/supabase'
 
 export function ProfileWithRelationship({
 	otherPerson,
+	relationship,
 }: {
 	otherPerson: PublicProfileFull
+	relationship?: null | Tables<'friend_summary'>
 }) {
 	const { userId } = useAuth()
 	const [uid_less, uid_more] = [userId, otherPerson.uid].sort()
@@ -51,6 +54,8 @@ export function ProfileWithRelationship({
 		},
 	})
 
+	relationship ??= otherPerson.friend_summary ?? null
+
 	return (
 		<AvatarIconRow {...otherPerson}>
 			<div className="flex flex-row gap-2">
@@ -62,10 +67,7 @@ export function ProfileWithRelationship({
 					<span className="bg-green-600 h-8 w-8 rounded-full p-1">
 						<Check className="text-white w-6 h-6" />
 					</span>
-				: (
-					!otherPerson.friend_summary ||
-					otherPerson.friend_summary.status === 'unconnected'
-				) ?
+				: !relationship || relationship.status === 'unconnected' ?
 					<Button
 						variant="default"
 						className="w-8 h-8"
@@ -76,8 +78,8 @@ export function ProfileWithRelationship({
 						<Send className="w-6 h-6 mr-[0.1rem] mt-[0.1rem]" />
 					</Button>
 				: (
-					otherPerson.friend_summary?.status === 'pending' &&
-					userId === otherPerson.friend_summary?.most_recent_uid_for
+					relationship?.status === 'pending' &&
+					userId === relationship?.most_recent_uid_for
 				) ?
 					<>
 						<Button
@@ -100,8 +102,8 @@ export function ProfileWithRelationship({
 						</Button>
 					</>
 				: (
-					otherPerson.friend_summary?.status === 'pending' &&
-					userId === otherPerson.friend_summary?.most_recent_uid_by
+					relationship?.status === 'pending' &&
+					userId === relationship?.most_recent_uid_by
 				) ?
 					<Button
 						variant="secondary"
@@ -112,16 +114,8 @@ export function ProfileWithRelationship({
 					>
 						<X className="w-6 h-6 p-0" />
 					</Button>
-				: otherPerson.friend_summary.status === 'friends' ?
-					<Button
-						variant="secondary"
-						className="w-8 h-8"
-						size="icon"
-						title="Disconnect from this person (you will lose access to each other's decks)"
-						onClick={() => inviteResponseMutation.mutate('remove')}
-					>
-						<X className="w-6 h-6 p-0" />
-					</Button>
+				: relationship.status === 'friends' ?
+					<Handshake className="w-6 h-6 p-0" />
 				:	<> status is null for some reason</>}
 			</div>
 		</AvatarIconRow>

--- a/src/components/profile-with-relationship.tsx
+++ b/src/components/profile-with-relationship.tsx
@@ -1,0 +1,129 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import { Check, Loader2, Send, ThumbsUp, X } from 'lucide-react'
+
+import type { PublicProfileFull, FriendRequestActionInsert } from '@/types/main'
+import { Button } from '@/components/ui/button'
+import { AvatarIconRow } from '@/components/ui/avatar-icon'
+import supabase from '@/lib/supabase-client'
+import { useAuth } from '@/lib/hooks'
+
+export function ProfileWithRelationship({
+	otherPerson,
+}: {
+	otherPerson: PublicProfileFull
+}) {
+	const { userId } = useAuth()
+	const [uid_less, uid_more] = [userId, otherPerson.uid].sort()
+	const queryClient = useQueryClient()
+	const inviteResponseMutation = useMutation({
+		mutationKey: ['user', 'friend_request_action'],
+		mutationFn: async (action_type: string) => {
+			await supabase
+				.from('friend_request_action')
+				.insert({
+					uid_less,
+					uid_more,
+					uid_by: userId,
+					uid_for: otherPerson.uid,
+					action_type,
+				} as FriendRequestActionInsert)
+				.throwOnError()
+		},
+		onSuccess: (_, variable) => {
+			if (variable === 'invite') toast.success('Friend request sent 👍')
+			if (variable === 'accept')
+				toast.success('Accepted invitation. You are now connected 👍')
+			if (variable === 'decline') toast('Declined this invitation')
+			if (variable === 'cancel') toast('Cancelled this invitation')
+			if (variable === 'remove') toast('You are no longer friends')
+			void queryClient.invalidateQueries({
+				queryKey: ['user', 'friends', 'summaries'],
+			})
+		},
+		onError: (error, variables) => {
+			console.log(
+				`Something went wrong trying to modify your relationship:`,
+				error,
+				variables
+			)
+			toast.error(`Something went wrong with this interaction`)
+		},
+	})
+
+	return (
+		<AvatarIconRow {...otherPerson}>
+			<div className="flex flex-row gap-2">
+				{inviteResponseMutation.isPending ?
+					<span className="h-8 w-8 rounded-full p-1">
+						<Loader2 className="w-6 h-6" />
+					</span>
+				: inviteResponseMutation.isSuccess ?
+					<span className="bg-green-600 h-8 w-8 rounded-full p-1">
+						<Check className="text-white w-6 h-6" />
+					</span>
+				: (
+					!otherPerson.friend_summary ||
+					otherPerson.friend_summary.status === 'unconnected'
+				) ?
+					<Button
+						variant="default"
+						className="w-8 h-8"
+						size="icon"
+						title="Send friend request"
+						onClick={() => inviteResponseMutation.mutate('invite')}
+					>
+						<Send className="w-6 h-6 mr-[0.1rem] mt-[0.1rem]" />
+					</Button>
+				: (
+					otherPerson.friend_summary?.status === 'pending' &&
+					userId === otherPerson.friend_summary?.most_recent_uid_for
+				) ?
+					<>
+						<Button
+							variant="default"
+							className="w-8 h-8"
+							size="icon"
+							title="Accept pending invitation"
+							onClick={() => inviteResponseMutation.mutate('accept')}
+						>
+							<ThumbsUp />
+						</Button>
+						<Button
+							variant="secondary"
+							className="w-8 h-8"
+							size="icon"
+							title="Decline pending invitation"
+							onClick={() => inviteResponseMutation.mutate('decline')}
+						>
+							<X className="w-6 h-6 p-0" />
+						</Button>
+					</>
+				: (
+					otherPerson.friend_summary?.status === 'pending' &&
+					userId === otherPerson.friend_summary?.most_recent_uid_by
+				) ?
+					<Button
+						variant="secondary"
+						className="w-8 h-8"
+						size="icon"
+						title="Cancel friend request"
+						onClick={() => inviteResponseMutation.mutate('cancel')}
+					>
+						<X className="w-6 h-6 p-0" />
+					</Button>
+				: otherPerson.friend_summary.status === 'friends' ?
+					<Button
+						variant="secondary"
+						className="w-8 h-8"
+						size="icon"
+						title="Disconnect from this person (you will lose access to each other's decks)"
+						onClick={() => inviteResponseMutation.mutate('remove')}
+					>
+						<X className="w-6 h-6 p-0" />
+					</Button>
+				:	<> status is null for some reason</>}
+			</div>
+		</AvatarIconRow>
+	)
+}

--- a/src/components/profile-with-relationship.tsx
+++ b/src/components/profile-with-relationship.tsx
@@ -104,15 +104,42 @@ export function ProfileWithRelationship({
 						>
 							<ThumbsUp />
 						</Button>
-						<Button
-							variant="secondary"
-							className="w-8 h-8"
-							size="icon"
-							title="Decline pending invitation"
-							onClick={() => inviteResponseMutation.mutate('decline')}
-						>
-							<X className="w-6 h-6 p-0" />
-						</Button>
+						<Dialog>
+							<DialogTrigger asChild>
+								<Button
+									variant="secondary"
+									className="w-8 h-8"
+									size="icon"
+									title="Decline pending invitation"
+								>
+									<X className="w-6 h-6 p-0" />
+								</Button>
+							</DialogTrigger>
+							<DialogContent>
+								<DialogHeader>
+									<DialogTitle>Decline this invitation</DialogTitle>
+									<DialogDescription>
+										Please confirm whether you'd like to decline this invitation
+									</DialogDescription>
+								</DialogHeader>
+								<DialogFooter>
+									<DialogClose asChild>
+										<Button variant="secondary">Go back</Button>
+									</DialogClose>
+									<Button
+										variant="destructive"
+										title="Confirm: Cancel friend request"
+										onClick={() => inviteResponseMutation.mutate('decline')}
+									>
+										{inviteResponseMutation.isPending ?
+											<Loader2 />
+										: inviteResponseMutation.isSuccess ?
+											<Check className="text-white w-6 h-6" />
+										:	<>Confirm</>}
+									</Button>
+								</DialogFooter>
+							</DialogContent>
+						</Dialog>
 					</>
 				: (
 					relationship?.status === 'pending' &&
@@ -131,12 +158,13 @@ export function ProfileWithRelationship({
 						</DialogTrigger>
 						<DialogContent className="sm:max-w-[425px]">
 							<DialogHeader>
-								<DialogTitle>Cancel this invitation</DialogTitle>
+								<DialogTitle>Cancel this request</DialogTitle>
 								<DialogDescription>
-									Please confirm whether you'd like to cancel this invitation
+									Please confirm whether you'd like to cancel this friend
+									request
 								</DialogDescription>
 							</DialogHeader>
-							<DialogFooter className="justify-between">
+							<DialogFooter>
 								<DialogClose asChild>
 									<Button variant="secondary">Go back</Button>
 								</DialogClose>

--- a/src/components/profile-with-relationship.tsx
+++ b/src/components/profile-with-relationship.tsx
@@ -20,7 +20,7 @@ export function ProfileWithRelationship({
 	const [uid_less, uid_more] = [userId, otherPerson.uid].sort()
 	const queryClient = useQueryClient()
 	const inviteResponseMutation = useMutation({
-		mutationKey: ['user', 'friend_request_action'],
+		mutationKey: ['user', 'friend_request_action', otherPerson.uid],
 		mutationFn: async (action_type: string) => {
 			await supabase
 				.from('friend_request_action')

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -41,6 +41,7 @@ const GenericMenu = ({ menu }: { menu: MenuType }) => {
 				:	<Link
 						className="nav-link"
 						to={menu.to as string}
+						params={menu.params}
 						activeOptions={{
 							exact: true,
 						}}
@@ -52,7 +53,7 @@ const GenericMenu = ({ menu }: { menu: MenuType }) => {
 			<ul className="flex flex-col gap-2">
 				{menu.links?.map((i) => (
 					<li key={`${i.to}-${i.params ? JSON.stringify(i.params) : ''}`}>
-						<Link className="nav-link" to={i.to as string}>
+						<Link className="nav-link" to={i.to as string} params={i.params}>
 							{i.name}
 						</Link>
 					</li>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -8,7 +8,7 @@ import { useProfile } from '@/lib/use-profile'
 import { useAuth, useSignOut } from '@/lib/hooks'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { LogOut } from 'lucide-react'
+import { CircleUser, LogOut } from 'lucide-react'
 import { ModeToggle } from './mode-toggle'
 import Avatar from './avatar'
 import Callout from './ui/callout'
@@ -126,6 +126,12 @@ function DeckMenu() {
 				<p className="flex flex-row gap-2">
 					<Avatar size={24} />
 					Your profile
+				</p>
+			</Link>
+			<Link to="/friends" className="nav-link">
+				<p className="flex flex-row gap-2">
+					<CircleUser size={24} />
+					Your friends
 				</p>
 			</Link>
 			{data.deckLanguages.length === 0 ?

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -86,7 +86,7 @@ const DialogTitle = React.forwardRef<
 	<DialogPrimitive.Title
 		ref={ref}
 		className={cn(
-			'text-lg font-semibold leading-none tracking-tight',
+			'text-lg font-semibold text-foreground/90 leading-none tracking-tight',
 			className
 		)}
 		{...props}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -22,21 +22,22 @@ import { Route as LearnAddDeckImport } from './routes/learn/add-deck'
 import { Route as LearnLangImport } from './routes/learn/$lang'
 import { Route as UserProfileImport } from './routes/_user/profile'
 import { Route as UserGettingStartedImport } from './routes/_user/getting-started'
+import { Route as UserFriendsImport } from './routes/_user/friends'
 import { Route as UserAcceptInviteImport } from './routes/_user/accept-invite'
 import { Route as AuthLoginImport } from './routes/_auth/login'
 import { Route as AuthFindAFriendImport } from './routes/_auth/find-a-friend'
 import { Route as LearnLangIndexImport } from './routes/learn/$lang/index'
 import { Route as UserProfileIndexImport } from './routes/_user/profile.index'
+import { Route as UserFriendsIndexImport } from './routes/_user/friends.index'
 import { Route as LearnLangSearchImport } from './routes/learn/$lang/search'
 import { Route as LearnLangReviewImport } from './routes/learn/$lang/review'
 import { Route as LearnLangPublicLibraryImport } from './routes/learn/$lang/public-library'
 import { Route as LearnLangDeckSettingsImport } from './routes/learn/$lang/deck-settings'
 import { Route as LearnLangAddPhraseImport } from './routes/learn/$lang/add-phrase'
-import { Route as UserProfileFriendRequestImport } from './routes/_user/profile.friend-request'
-import { Route as UserProfileFriendListImport } from './routes/_user/profile.friend-list'
-import { Route as UserProfileFriendInviteImport } from './routes/_user/profile.friend-invite'
 import { Route as UserProfileChangePasswordImport } from './routes/_user/profile.change-password'
 import { Route as UserProfileChangeEmailImport } from './routes/_user/profile.change-email'
+import { Route as UserFriendsRequestImport } from './routes/_user/friends.request'
+import { Route as UserFriendsInviteImport } from './routes/_user/friends.invite'
 
 // Create Virtual Routes
 
@@ -138,6 +139,11 @@ const UserGettingStartedRoute = UserGettingStartedImport.update({
   getParentRoute: () => UserRoute,
 } as any)
 
+const UserFriendsRoute = UserFriendsImport.update({
+  path: '/friends',
+  getParentRoute: () => UserRoute,
+} as any)
+
 const UserAcceptInviteRoute = UserAcceptInviteImport.update({
   path: '/accept-invite',
   getParentRoute: () => UserRoute,
@@ -161,6 +167,11 @@ const LearnLangIndexRoute = LearnLangIndexImport.update({
 const UserProfileIndexRoute = UserProfileIndexImport.update({
   path: '/',
   getParentRoute: () => UserProfileRoute,
+} as any)
+
+const UserFriendsIndexRoute = UserFriendsIndexImport.update({
+  path: '/',
+  getParentRoute: () => UserFriendsRoute,
 } as any)
 
 const LearnLangSearchRoute = LearnLangSearchImport.update({
@@ -188,21 +199,6 @@ const LearnLangAddPhraseRoute = LearnLangAddPhraseImport.update({
   getParentRoute: () => LearnLangRoute,
 } as any)
 
-const UserProfileFriendRequestRoute = UserProfileFriendRequestImport.update({
-  path: '/friend-request',
-  getParentRoute: () => UserProfileRoute,
-} as any)
-
-const UserProfileFriendListRoute = UserProfileFriendListImport.update({
-  path: '/friend-list',
-  getParentRoute: () => UserProfileRoute,
-} as any)
-
-const UserProfileFriendInviteRoute = UserProfileFriendInviteImport.update({
-  path: '/friend-invite',
-  getParentRoute: () => UserProfileRoute,
-} as any)
-
 const UserProfileChangePasswordRoute = UserProfileChangePasswordImport.update({
   path: '/change-password',
   getParentRoute: () => UserProfileRoute,
@@ -211,6 +207,16 @@ const UserProfileChangePasswordRoute = UserProfileChangePasswordImport.update({
 const UserProfileChangeEmailRoute = UserProfileChangeEmailImport.update({
   path: '/change-email',
   getParentRoute: () => UserProfileRoute,
+} as any)
+
+const UserFriendsRequestRoute = UserFriendsRequestImport.update({
+  path: '/request',
+  getParentRoute: () => UserFriendsRoute,
+} as any)
+
+const UserFriendsInviteRoute = UserFriendsInviteImport.update({
+  path: '/invite',
+  getParentRoute: () => UserFriendsRoute,
 } as any)
 
 // Populate the FileRoutesByPath interface
@@ -287,6 +293,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserAcceptInviteImport
       parentRoute: typeof UserImport
     }
+    '/_user/friends': {
+      id: '/_user/friends'
+      path: '/friends'
+      fullPath: '/friends'
+      preLoaderRoute: typeof UserFriendsImport
+      parentRoute: typeof UserImport
+    }
     '/_user/getting-started': {
       id: '/_user/getting-started'
       path: '/getting-started'
@@ -350,6 +363,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LearnIndexImport
       parentRoute: typeof LearnImport
     }
+    '/_user/friends/invite': {
+      id: '/_user/friends/invite'
+      path: '/invite'
+      fullPath: '/friends/invite'
+      preLoaderRoute: typeof UserFriendsInviteImport
+      parentRoute: typeof UserFriendsImport
+    }
+    '/_user/friends/request': {
+      id: '/_user/friends/request'
+      path: '/request'
+      fullPath: '/friends/request'
+      preLoaderRoute: typeof UserFriendsRequestImport
+      parentRoute: typeof UserFriendsImport
+    }
     '/_user/profile/change-email': {
       id: '/_user/profile/change-email'
       path: '/change-email'
@@ -362,27 +389,6 @@ declare module '@tanstack/react-router' {
       path: '/change-password'
       fullPath: '/profile/change-password'
       preLoaderRoute: typeof UserProfileChangePasswordImport
-      parentRoute: typeof UserProfileImport
-    }
-    '/_user/profile/friend-invite': {
-      id: '/_user/profile/friend-invite'
-      path: '/friend-invite'
-      fullPath: '/profile/friend-invite'
-      preLoaderRoute: typeof UserProfileFriendInviteImport
-      parentRoute: typeof UserProfileImport
-    }
-    '/_user/profile/friend-list': {
-      id: '/_user/profile/friend-list'
-      path: '/friend-list'
-      fullPath: '/profile/friend-list'
-      preLoaderRoute: typeof UserProfileFriendListImport
-      parentRoute: typeof UserProfileImport
-    }
-    '/_user/profile/friend-request': {
-      id: '/_user/profile/friend-request'
-      path: '/friend-request'
-      fullPath: '/profile/friend-request'
-      preLoaderRoute: typeof UserProfileFriendRequestImport
       parentRoute: typeof UserProfileImport
     }
     '/learn/$lang/add-phrase': {
@@ -420,6 +426,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LearnLangSearchImport
       parentRoute: typeof LearnLangImport
     }
+    '/_user/friends/': {
+      id: '/_user/friends/'
+      path: '/'
+      fullPath: '/friends/'
+      preLoaderRoute: typeof UserFriendsIndexImport
+      parentRoute: typeof UserFriendsImport
+    }
     '/_user/profile/': {
       id: '/_user/profile/'
       path: '/'
@@ -450,13 +463,15 @@ export const routeTree = rootRoute.addChildren({
   }),
   UserRoute: UserRoute.addChildren({
     UserAcceptInviteRoute,
+    UserFriendsRoute: UserFriendsRoute.addChildren({
+      UserFriendsInviteRoute,
+      UserFriendsRequestRoute,
+      UserFriendsIndexRoute,
+    }),
     UserGettingStartedRoute,
     UserProfileRoute: UserProfileRoute.addChildren({
       UserProfileChangeEmailRoute,
       UserProfileChangePasswordRoute,
-      UserProfileFriendInviteRoute,
-      UserProfileFriendListRoute,
-      UserProfileFriendRequestRoute,
       UserProfileIndexRoute,
     }),
   }),
@@ -512,6 +527,7 @@ export const routeTree = rootRoute.addChildren({
       "filePath": "_user.tsx",
       "children": [
         "/_user/accept-invite",
+        "/_user/friends",
         "/_user/getting-started",
         "/_user/profile"
       ]
@@ -546,6 +562,15 @@ export const routeTree = rootRoute.addChildren({
       "filePath": "_user/accept-invite.tsx",
       "parent": "/_user"
     },
+    "/_user/friends": {
+      "filePath": "_user/friends.tsx",
+      "parent": "/_user",
+      "children": [
+        "/_user/friends/invite",
+        "/_user/friends/request",
+        "/_user/friends/"
+      ]
+    },
     "/_user/getting-started": {
       "filePath": "_user/getting-started.tsx",
       "parent": "/_user"
@@ -556,9 +581,6 @@ export const routeTree = rootRoute.addChildren({
       "children": [
         "/_user/profile/change-email",
         "/_user/profile/change-password",
-        "/_user/profile/friend-invite",
-        "/_user/profile/friend-list",
-        "/_user/profile/friend-request",
         "/_user/profile/"
       ]
     },
@@ -598,24 +620,20 @@ export const routeTree = rootRoute.addChildren({
       "filePath": "learn/index.tsx",
       "parent": "/learn"
     },
+    "/_user/friends/invite": {
+      "filePath": "_user/friends.invite.tsx",
+      "parent": "/_user/friends"
+    },
+    "/_user/friends/request": {
+      "filePath": "_user/friends.request.tsx",
+      "parent": "/_user/friends"
+    },
     "/_user/profile/change-email": {
       "filePath": "_user/profile.change-email.tsx",
       "parent": "/_user/profile"
     },
     "/_user/profile/change-password": {
       "filePath": "_user/profile.change-password.tsx",
-      "parent": "/_user/profile"
-    },
-    "/_user/profile/friend-invite": {
-      "filePath": "_user/profile.friend-invite.tsx",
-      "parent": "/_user/profile"
-    },
-    "/_user/profile/friend-list": {
-      "filePath": "_user/profile.friend-list.tsx",
-      "parent": "/_user/profile"
-    },
-    "/_user/profile/friend-request": {
-      "filePath": "_user/profile.friend-request.tsx",
       "parent": "/_user/profile"
     },
     "/learn/$lang/add-phrase": {
@@ -637,6 +655,10 @@ export const routeTree = rootRoute.addChildren({
     "/learn/$lang/search": {
       "filePath": "learn/$lang/search.tsx",
       "parent": "/learn/$lang"
+    },
+    "/_user/friends/": {
+      "filePath": "_user/friends.index.tsx",
+      "parent": "/_user/friends"
     },
     "/_user/profile/": {
       "filePath": "_user/profile.index.tsx",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as LearnLangPublicLibraryImport } from './routes/learn/$lang/publ
 import { Route as LearnLangDeckSettingsImport } from './routes/learn/$lang/deck-settings'
 import { Route as LearnLangAddPhraseImport } from './routes/learn/$lang/add-phrase'
 import { Route as UserProfileFriendRequestImport } from './routes/_user/profile.friend-request'
+import { Route as UserProfileFriendListImport } from './routes/_user/profile.friend-list'
 import { Route as UserProfileFriendInviteImport } from './routes/_user/profile.friend-invite'
 import { Route as UserProfileChangePasswordImport } from './routes/_user/profile.change-password'
 import { Route as UserProfileChangeEmailImport } from './routes/_user/profile.change-email'
@@ -189,6 +190,11 @@ const LearnLangAddPhraseRoute = LearnLangAddPhraseImport.update({
 
 const UserProfileFriendRequestRoute = UserProfileFriendRequestImport.update({
   path: '/friend-request',
+  getParentRoute: () => UserProfileRoute,
+} as any)
+
+const UserProfileFriendListRoute = UserProfileFriendListImport.update({
+  path: '/friend-list',
   getParentRoute: () => UserProfileRoute,
 } as any)
 
@@ -365,6 +371,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserProfileFriendInviteImport
       parentRoute: typeof UserProfileImport
     }
+    '/_user/profile/friend-list': {
+      id: '/_user/profile/friend-list'
+      path: '/friend-list'
+      fullPath: '/profile/friend-list'
+      preLoaderRoute: typeof UserProfileFriendListImport
+      parentRoute: typeof UserProfileImport
+    }
     '/_user/profile/friend-request': {
       id: '/_user/profile/friend-request'
       path: '/friend-request'
@@ -442,6 +455,7 @@ export const routeTree = rootRoute.addChildren({
       UserProfileChangeEmailRoute,
       UserProfileChangePasswordRoute,
       UserProfileFriendInviteRoute,
+      UserProfileFriendListRoute,
       UserProfileFriendRequestRoute,
       UserProfileIndexRoute,
     }),
@@ -543,6 +557,7 @@ export const routeTree = rootRoute.addChildren({
         "/_user/profile/change-email",
         "/_user/profile/change-password",
         "/_user/profile/friend-invite",
+        "/_user/profile/friend-list",
         "/_user/profile/friend-request",
         "/_user/profile/"
       ]
@@ -593,6 +608,10 @@ export const routeTree = rootRoute.addChildren({
     },
     "/_user/profile/friend-invite": {
       "filePath": "_user/profile.friend-invite.tsx",
+      "parent": "/_user/profile"
+    },
+    "/_user/profile/friend-list": {
+      "filePath": "_user/profile.friend-list.tsx",
       "parent": "/_user/profile"
     },
     "/_user/profile/friend-request": {

--- a/src/routes/_user/friends.index.tsx
+++ b/src/routes/_user/friends.index.tsx
@@ -74,7 +74,25 @@ function FriendProfiles() {
 					: error ?
 						<></>
 					: !(data?.uids.friends?.length > 0) ?
-						<>no friends</>
+						<p>
+							Your friends list is empty for now. Use{' '}
+							<Link
+								className="s-link"
+								from={Route.fullPath}
+								to="/friends/request"
+							>
+								the search screen
+							</Link>{' '}
+							to find friends on Sunlo or{' '}
+							<Link
+								className="s-link"
+								from={Route.fullPath}
+								to="/friends/invite"
+							>
+								invite them to create an account
+							</Link>
+							.
+						</p>
 					:	data?.uids.friends.map((uid) => (
 							<ProfileWithRelationship
 								key={uid}

--- a/src/routes/_user/friends.index.tsx
+++ b/src/routes/_user/friends.index.tsx
@@ -72,7 +72,10 @@ function FriendProfiles() {
 						<></>
 					: !(data?.length > 0) ?
 						<>no friends</>
-					:	data.map((f) => <ProfileWithRelationship otherPerson={f} />)}
+					:	data.map((otherPerson) => (
+							<ProfileWithRelationship otherPerson={otherPerson} />
+						))
+					}
 				</div>
 			</CardContent>
 		</Card>

--- a/src/routes/_user/friends.index.tsx
+++ b/src/routes/_user/friends.index.tsx
@@ -38,7 +38,7 @@ function PendingRequestsSection() {
 				:	data.uids.invited.map((uid) => (
 						<ProfileWithRelationship
 							key={uid}
-							otherPerson={data.relationsMap[uid]}
+							otherPerson={data?.relationsMap[uid]}
 						/>
 					))
 				}

--- a/src/routes/_user/friends.index.tsx
+++ b/src/routes/_user/friends.index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { buttonVariants } from '@/components/ui/button'
 import { Loader2, Search } from 'lucide-react'
-import { useFriendsInvited, useFriends } from '@/lib/friends'
+import { useRelationsQuery } from '@/lib/friends'
 import { ShowError } from '@/components/errors'
 import { ProfileWithRelationship } from '@/components/profile-with-relationship'
 
@@ -21,7 +21,7 @@ function FriendListPage() {
 }
 
 function PendingRequestsSection() {
-	const { data, isPending, error } = useFriendsInvited()
+	const { data, isPending, error } = useRelationsQuery()
 
 	return (
 		<Card>
@@ -33,10 +33,13 @@ function PendingRequestsSection() {
 					<Loader2 />
 				: error ?
 					<ShowError>{error.message}</ShowError>
-				: !(data?.length > 0) ?
+				: !(data?.uids.invited.length > 0) ?
 					<p>You don't have any requests pending at this time.</p>
-				:	data.map((person) => (
-						<ProfileWithRelationship key={person.uid} otherPerson={person} />
+				:	data.uids.invited.map((uid) => (
+						<ProfileWithRelationship
+							key={uid}
+							otherPerson={data.relationsMap[uid]}
+						/>
 					))
 				}
 			</CardContent>
@@ -45,7 +48,7 @@ function PendingRequestsSection() {
 }
 
 function FriendProfiles() {
-	const { data, isPending, error } = useFriends()
+	const { data, isPending, error } = useRelationsQuery()
 	return (
 		<Card>
 			<CardHeader>
@@ -70,10 +73,13 @@ function FriendProfiles() {
 						<Loader2 />
 					: error ?
 						<></>
-					: !(data?.length > 0) ?
+					: !(data?.uids.friends?.length > 0) ?
 						<>no friends</>
-					:	data.map((otherPerson) => (
-							<ProfileWithRelationship otherPerson={otherPerson} />
+					:	data?.uids.friends.map((uid) => (
+							<ProfileWithRelationship
+								key={uid}
+								otherPerson={data?.relationsMap[uid]}
+							/>
 						))
 					}
 				</div>

--- a/src/routes/_user/friends.index.tsx
+++ b/src/routes/_user/friends.index.tsx
@@ -7,15 +7,15 @@ import { useFriendsInvited, useFriends } from '@/lib/friends'
 import { ShowError } from '@/components/errors'
 import { ProfileWithRelationship } from '@/components/profile-with-relationship'
 
-export const Route = createFileRoute('/_user/profile/friend-list')({
+export const Route = createFileRoute('/_user/friends/')({
 	component: FriendListPage,
 })
 
 function FriendListPage() {
 	return (
 		<main className="flex flex-col gap-6">
-			<PendingRequestsSection />
 			<FriendProfiles />
+			<PendingRequestsSection />
 		</main>
 	)
 }
@@ -26,7 +26,7 @@ function PendingRequestsSection() {
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Pending requests</CardTitle>
+				<CardTitle>Friend requests sent</CardTitle>
 			</CardHeader>
 			<CardContent className="space-y-4">
 				{isPending ?
@@ -53,7 +53,7 @@ function FriendProfiles() {
 					<div className="flex flex-row justify-between items-center">
 						<span>Your friends</span>
 						<Link
-							to="/profile/friend-request"
+							to="/friends/request"
 							search
 							aria-disabled="true"
 							className={buttonVariants({ size: 'badge', variant: 'outline' })}

--- a/src/routes/_user/friends.invite.tsx
+++ b/src/routes/_user/friends.invite.tsx
@@ -18,7 +18,7 @@ import { Label } from '@/components/ui/label'
 import { Search, Send } from 'lucide-react'
 import { ShowError } from '@/components/errors'
 
-export const Route = createFileRoute('/_user/profile/friend-invite')({
+export const Route = createFileRoute('/_user/friends/invite')({
 	component: InviteFriendPage,
 })
 
@@ -65,7 +65,7 @@ function InviteFriendForm() {
 					<div className="flex flex-row justify-between items-center">
 						<span>Invite a Friend</span>
 						<Link
-							to="/profile/friend-request"
+							to="/friends/request"
 							aria-disabled="true"
 							className={buttonVariants({ size: 'badge', variant: 'outline' })}
 						>

--- a/src/routes/_user/friends.request.tsx
+++ b/src/routes/_user/friends.request.tsx
@@ -96,6 +96,7 @@ const searchAsync = async (query: string): Promise<PublicProfile[]> => {
 
 export default function SearchProfiles() {
 	const { query } = Route.useSearch()
+	const { data } = useRelationsQuery()
 	const debouncedQuery = useDebounce(query, 500)
 	const navigate = useNavigate({ from: Route.fullPath })
 	const setQueryInputValue = (val: string) =>
@@ -196,6 +197,9 @@ export default function SearchProfiles() {
 									<ProfileWithRelationship
 										key={person.uid}
 										otherPerson={person}
+										relationship={
+											data.relationsMap[person.uid].friend_summary || null
+										}
 									/>
 								))
 							}

--- a/src/routes/_user/friends.request.tsx
+++ b/src/routes/_user/friends.request.tsx
@@ -198,7 +198,7 @@ export default function SearchProfiles() {
 										key={person.uid}
 										otherPerson={person}
 										relationship={
-											data.relationsMap[person.uid].friend_summary || null
+											data?.relationsMap[person.uid].friend_summary || null
 										}
 									/>
 								))

--- a/src/routes/_user/friends.request.tsx
+++ b/src/routes/_user/friends.request.tsx
@@ -16,7 +16,7 @@ import {
 import { Input } from '@/components/ui/input'
 import Callout from '@/components/ui/callout'
 
-import { useFriendInvitations } from '@/lib/friends'
+import { useRelationsQuery } from '@/lib/friends'
 import Loading from '@/components/loading'
 import type { PublicProfile } from '@/types/main'
 import supabase from '@/lib/supabase-client'
@@ -45,7 +45,7 @@ function FriendRequestPage() {
 }
 
 function PendingInvitationsSection() {
-	const { data, isPending, error } = useFriendInvitations()
+	const { data, isPending, error } = useRelationsQuery()
 
 	return (
 		<Card>
@@ -69,10 +69,13 @@ function PendingInvitationsSection() {
 					<Loading />
 				: error ?
 					<ShowError>{error.message}</ShowError>
-				: !(data?.length > 0) ?
+				: !(data?.uids.invitations?.length > 0) ?
 					<p>You don't have any pending invitations at this time.</p>
-				:	data.map((person) => (
-						<ProfileWithRelationship key={person.uid} otherPerson={person} />
+				:	data?.uids.invitations.map((uid) => (
+						<ProfileWithRelationship
+							key={uid}
+							otherPerson={data?.relationsMap[uid]}
+						/>
 					))
 				}
 			</CardContent>

--- a/src/routes/_user/friends.request.tsx
+++ b/src/routes/_user/friends.request.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import { useDebounce, usePrevious } from '@uidotdev/usehooks'
-import { Loader2, Search, Send } from 'lucide-react'
+import { Contact, Loader2, Mail, Search, Send } from 'lucide-react'
 
 import { Button, buttonVariants } from '@/components/ui/button'
 import {
@@ -25,13 +25,14 @@ import { ShowError } from '@/components/errors'
 import { Garlic } from '@/components/garlic'
 import { Label } from '@/components/ui/label'
 import { ProfileWithRelationship } from '@/components/profile-with-relationship'
+import { EmailField } from '@/components/fields'
 
 const SearchSchema = z.object({
 	query: z.string().optional(),
 	lang: z.string().optional(),
 })
 
-export const Route = createFileRoute('/_user/profile/friend-request')({
+export const Route = createFileRoute('/_user/friends/request')({
 	component: FriendRequestPage,
 	validateSearch: (search) => SearchSchema.parse(search),
 })
@@ -51,7 +52,19 @@ function PendingInvitationsSection() {
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle>Invitations from friends</CardTitle>
+				<CardTitle>
+					<div className="flex flex-row justify-between items-center">
+						<span>Invitations to connect</span>
+						<Link
+							to="/friends"
+							aria-disabled="true"
+							className={buttonVariants({ size: 'badge', variant: 'outline' })}
+						>
+							<Contact className="h-3 w-3" />{' '}
+							<span className="me-1">Friends list</span>
+						</Link>
+					</div>
+				</CardTitle>
 			</CardHeader>
 			<CardContent className="space-y-4">
 				{isPending ?
@@ -117,11 +130,11 @@ export default function SearchProfiles() {
 					<div className="flex flex-row justify-between items-center">
 						<span>Search for friends</span>
 						<Link
-							to="/profile/friend-invite"
+							to="/friends/invite"
 							aria-disabled="true"
 							className={buttonVariants({ size: 'badge', variant: 'outline' })}
 						>
-							<Send className="h-3 w-3" /> <span className="me-1">Invite</span>
+							<Mail className="h-3 w-3" /> <span className="me-1">Invite</span>
 						</Link>
 					</div>
 				</CardTitle>
@@ -171,7 +184,7 @@ export default function SearchProfiles() {
 										<p>
 											<Link
 												className={buttonVariants({ variant: 'secondary' })}
-												to="/profile/friend-invite"
+												to="/friends/invite"
 												from={Route.fullPath}
 											>
 												Invite a friend to Sunlo

--- a/src/routes/_user/friends.tsx
+++ b/src/routes/_user/friends.tsx
@@ -2,32 +2,32 @@ import Navbar from '@/components/navbar'
 import { NavbarData } from '@/types/main'
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
-export const Route = createFileRoute('/_user/profile')({
-	component: ProfilePage,
+export const Route = createFileRoute('/_user/friends')({
+	component: FriendsPage,
 	loader: () => ({
 		navbar: {
-			title: `Profile Menu`,
+			title: `Manage Friends and Contacts`,
 			icon: '',
 			contextMenu: [
+				{
+					name: 'Friends list',
+					to: '/friends',
+					icon: 'friend',
+				},
+				{
+					name: 'Browse profiles',
+					to: '/friends/request',
+					icon: 'handshake',
+				},
+				{
+					name: 'Invite to Sunlo',
+					to: '/friends/invite',
+					icon: 'invite',
+				},
 				{
 					name: 'Edit profile',
 					to: '/profile',
 					icon: 'notebook-pen',
-				},
-				{
-					name: 'Update email',
-					to: '/profile/change-email',
-					icon: 'email',
-				},
-				{
-					name: `Update password`,
-					to: '/profile/change-password',
-					icon: 'password',
-				},
-				{
-					name: 'Friends',
-					to: '/friends',
-					icon: 'friend',
 				},
 				{
 					name: 'Start a new Language',
@@ -39,7 +39,7 @@ export const Route = createFileRoute('/_user/profile')({
 	}),
 })
 
-function ProfilePage() {
+function FriendsPage() {
 	return (
 		<div className="w-app @container">
 			<Navbar />

--- a/src/routes/_user/getting-started.tsx
+++ b/src/routes/_user/getting-started.tsx
@@ -14,7 +14,7 @@ function GettingStartedPage() {
 	const { data: profile } = useProfile()
 
 	const nextPage =
-		userRole === 'learner' ? '/learn/add-deck' : '/profile/friend-request'
+		userRole === 'learner' ? '/learn/add-deck' : '/friends/request'
 
 	return (
 		profile === undefined ? <Loader2 className="mx-auto my-10" />

--- a/src/routes/_user/profile.friend-list.tsx
+++ b/src/routes/_user/profile.friend-list.tsx
@@ -1,0 +1,80 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { buttonVariants } from '@/components/ui/button'
+import { Loader2, Search } from 'lucide-react'
+import { useFriendsInvited, useFriends } from '@/lib/friends'
+import { ShowError } from '@/components/errors'
+import { ProfileWithRelationship } from '@/components/profile-with-relationship'
+
+export const Route = createFileRoute('/_user/profile/friend-list')({
+	component: FriendListPage,
+})
+
+function FriendListPage() {
+	return (
+		<main className="flex flex-col gap-6">
+			<PendingRequestsSection />
+			<FriendProfiles />
+		</main>
+	)
+}
+
+function PendingRequestsSection() {
+	const { data, isPending, error } = useFriendsInvited()
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Pending requests</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				{isPending ?
+					<Loader2 />
+				: error ?
+					<ShowError>{error.message}</ShowError>
+				: !(data?.length > 0) ?
+					<p>You don't have any requests pending at this time.</p>
+				:	data.map((person) => (
+						<ProfileWithRelationship key={person.uid} otherPerson={person} />
+					))
+				}
+			</CardContent>
+		</Card>
+	)
+}
+
+function FriendProfiles() {
+	const { data, isPending, error } = useFriends()
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>
+					<div className="flex flex-row justify-between items-center">
+						<span>Your friends</span>
+						<Link
+							to="/profile/friend-request"
+							search
+							aria-disabled="true"
+							className={buttonVariants({ size: 'badge', variant: 'outline' })}
+						>
+							<Search className="h-3 w-3" />{' '}
+							<span className="me-1">Search</span>
+						</Link>
+					</div>
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div className="space-y-2">
+					{isPending ?
+						<Loader2 />
+					: error ?
+						<></>
+					: !(data?.length > 0) ?
+						<>no friends</>
+					:	data.map((f) => <ProfileWithRelationship otherPerson={f} />)}
+				</div>
+			</CardContent>
+		</Card>
+	)
+}

--- a/src/routes/_user/profile.friend-request.tsx
+++ b/src/routes/_user/profile.friend-request.tsx
@@ -99,7 +99,11 @@ function ViewProfileWithRelationship({
 	return (
 		<AvatarIconRow {...otherPerson}>
 			<div className="flex flex-row gap-2">
-				{inviteResponseMutation.isSuccess ?
+				{inviteResponseMutation.isPending ?
+					<span className="h-8 w-8 rounded-full p-1">
+						<Loader2 className="w-6 h-6" />
+					</span>
+				: inviteResponseMutation.isSuccess ?
 					<span className="bg-green-600 h-8 w-8 rounded-full p-1">
 						<Check className="text-white w-6 h-6" />
 					</span>

--- a/src/routes/_user/profile.friend-request.tsx
+++ b/src/routes/_user/profile.friend-request.tsx
@@ -1,10 +1,10 @@
 import { useCallback } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
-import toast from 'react-hot-toast'
+
 import { useDebounce, usePrevious } from '@uidotdev/usehooks'
-import { Check, Loader2, Search, Send, ThumbsUp, X } from 'lucide-react'
+import { Loader2, Search, Send } from 'lucide-react'
 
 import { Button, buttonVariants } from '@/components/ui/button'
 import {
@@ -16,19 +16,15 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import Callout from '@/components/ui/callout'
-import { AvatarIconRow } from '@/components/ui/avatar-icon'
-import { useFriendInvitations, useFriendsInvited } from '@/lib/friends'
+
+import { useFriendInvitations } from '@/lib/friends'
 import Loading from '@/components/loading'
-import type {
-	PublicProfileFull,
-	FriendRequestActionInsert,
-	PublicProfile,
-} from '@/types/main'
+import type { PublicProfile } from '@/types/main'
 import supabase from '@/lib/supabase-client'
-import { useAuth } from '@/lib/hooks'
 import { ShowError } from '@/components/errors'
 import { Garlic } from '@/components/garlic'
 import { Label } from '@/components/ui/label'
+import { ProfileWithRelationship } from '@/components/profile-with-relationship'
 
 const SearchSchema = z.object({
 	query: z.string().optional(),
@@ -44,132 +40,8 @@ function FriendRequestPage() {
 	return (
 		<main className="flex flex-col gap-6">
 			<PendingInvitationsSection />
-			<PendingRequestsSection />
 			<SearchProfiles />
 		</main>
-	)
-}
-
-// we'll use uid_by and uid_for
-// uid_by is always the current user
-
-function ViewProfileWithRelationship({
-	otherPerson,
-}: {
-	otherPerson: PublicProfileFull
-}) {
-	const { userId } = useAuth()
-	const [uid_less, uid_more] = [userId, otherPerson.uid].sort()
-	const queryClient = useQueryClient()
-	const inviteResponseMutation = useMutation({
-		mutationKey: ['user', 'friend_request_action'],
-		mutationFn: async (action_type: string) => {
-			await supabase
-				.from('friend_request_action')
-				.insert({
-					uid_less,
-					uid_more,
-					uid_by: userId,
-					uid_for: otherPerson.uid,
-					action_type,
-				} as FriendRequestActionInsert)
-				.throwOnError()
-		},
-		onSuccess: (_, variable) => {
-			if (variable === 'invite') toast.success('Friend request sent 👍')
-			if (variable === 'accept')
-				toast.success('Accepted invitation. You are now connected 👍')
-			if (variable === 'decline') toast('Declined this invitation')
-			if (variable === 'cancel') toast('Cancelled this invitation')
-			if (variable === 'remove') toast('You are no longer friends')
-			void queryClient.invalidateQueries({
-				queryKey: ['user', 'friends', 'summaries'],
-			})
-		},
-		onError: (error, variables) => {
-			console.log(
-				`Something went wrong trying to modify your relationship:`,
-				error,
-				variables
-			)
-			toast.error(`Something went wrong with this interaction`)
-		},
-	})
-
-	return (
-		<AvatarIconRow {...otherPerson}>
-			<div className="flex flex-row gap-2">
-				{inviteResponseMutation.isPending ?
-					<span className="h-8 w-8 rounded-full p-1">
-						<Loader2 className="w-6 h-6" />
-					</span>
-				: inviteResponseMutation.isSuccess ?
-					<span className="bg-green-600 h-8 w-8 rounded-full p-1">
-						<Check className="text-white w-6 h-6" />
-					</span>
-				: (
-					!otherPerson.friend_summary ||
-					otherPerson.friend_summary.status === 'unconnected'
-				) ?
-					<Button
-						variant="default"
-						className="w-8 h-8"
-						size="icon"
-						title="Send friend request"
-						onClick={() => inviteResponseMutation.mutate('invite')}
-					>
-						<Send className="w-6 h-6 mr-[0.1rem] mt-[0.1rem]" />
-					</Button>
-				: (
-					otherPerson.friend_summary?.status === 'pending' &&
-					userId === otherPerson.friend_summary?.most_recent_uid_by
-				) ?
-					<Button
-						variant="secondary"
-						className="w-8 h-8"
-						size="icon"
-						title="Cancel friend request"
-						onClick={() => inviteResponseMutation.mutate('cancel')}
-					>
-						<X className="w-6 h-6 p-0" />
-					</Button>
-				: (
-					otherPerson.friend_summary?.status === 'pending' &&
-					userId === otherPerson.friend_summary?.most_recent_uid_for
-				) ?
-					<>
-						<Button
-							variant="default"
-							className="w-8 h-8"
-							size="icon"
-							title="Accept pending invitation"
-							onClick={() => inviteResponseMutation.mutate('accept')}
-						>
-							<ThumbsUp />
-						</Button>
-						<Button
-							variant="secondary"
-							className="w-8 h-8"
-							size="icon"
-							title="Decline pending invitation"
-							onClick={() => inviteResponseMutation.mutate('decline')}
-						>
-							<X className="w-6 h-6 p-0" />
-						</Button>
-					</>
-				: otherPerson.friend_summary.status === 'friends' ?
-					<Button
-						variant="secondary"
-						className="w-8 h-8"
-						size="icon"
-						title="Disconnect from this person (you will lose access to each other's decks)"
-						onClick={() => inviteResponseMutation.mutate('remove')}
-					>
-						<X className="w-6 h-6 p-0" />
-					</Button>
-				:	<> status is null for some reason</>}
-			</div>
-		</AvatarIconRow>
 	)
 }
 
@@ -189,37 +61,7 @@ function PendingInvitationsSection() {
 				: !(data?.length > 0) ?
 					<p>You don't have any pending invitations at this time.</p>
 				:	data.map((person) => (
-						<ViewProfileWithRelationship
-							key={person.uid}
-							otherPerson={person}
-						/>
-					))
-				}
-			</CardContent>
-		</Card>
-	)
-}
-
-function PendingRequestsSection() {
-	const { data, isPending, error } = useFriendsInvited()
-
-	return (
-		<Card>
-			<CardHeader>
-				<CardTitle>Pending requests</CardTitle>
-			</CardHeader>
-			<CardContent className="space-y-4">
-				{isPending ?
-					<Loading />
-				: error ?
-					<ShowError>{error.message}</ShowError>
-				: !(data?.length > 0) ?
-					<p>You don't have any requests pending at this time.</p>
-				:	data.map((person) => (
-						<ViewProfileWithRelationship
-							key={person.uid}
-							otherPerson={person}
-						/>
+						<ProfileWithRelationship key={person.uid} otherPerson={person} />
 					))
 				}
 			</CardContent>
@@ -338,7 +180,7 @@ export default function SearchProfiles() {
 									</div>
 								</Callout>
 							:	resultsToShow.map((person) => (
-									<ViewProfileWithRelationship
+									<ProfileWithRelationship
 										key={person.uid}
 										otherPerson={person}
 									/>

--- a/src/routes/_user/profile.index.tsx
+++ b/src/routes/_user/profile.index.tsx
@@ -62,7 +62,7 @@ function FriendsSection() {
 					<li>j-bhai (nothing special actually)</li>
 				</ul>
 				<Link
-					to="/profile/friend-request"
+					to="/friends/request"
 					from={Route.fullPath}
 					className={buttonVariants({ variant: 'secondary' })}
 				>

--- a/src/routes/_user/profile.tsx
+++ b/src/routes/_user/profile.tsx
@@ -10,7 +10,12 @@ export const Route = createFileRoute('/_user/profile')({
 			icon: '',
 			contextMenu: [
 				{
-					name: 'Connect with friends',
+					name: 'Friends list',
+					to: '/profile/friend-list',
+					icon: 'friend',
+				},
+				{
+					name: 'Browse profiles',
 					to: '/profile/friend-request',
 					icon: 'handshake',
 				},

--- a/src/routes/learn/$lang/deck-settings.tsx
+++ b/src/routes/learn/$lang/deck-settings.tsx
@@ -140,7 +140,7 @@ function ArchiveForm({ meta: { id, archived, lang } }: { meta: DeckMeta }) {
 
 	const mutation = useMutation({
 		mutationFn: async () => {
-			const { error } = await supabase
+			await supabase
 				.from('user_deck')
 				.update({ archived: !archived })
 				.eq('id', id)

--- a/src/routes/learn/$lang/index.tsx
+++ b/src/routes/learn/$lang/index.tsx
@@ -82,7 +82,7 @@ function FriendsSection({ lang }: LangOnlyComponentProps) {
 					<li>j-bhai (nothing special actually)</li>
 				</ul>
 				<Link
-					to="/profile/friend-request"
+					to="/friends/request"
 					search={{ lang }}
 					from={Route.fullPath}
 					className={buttonVariants({ variant: 'secondary' })}

--- a/src/routes/learn/add-deck.tsx
+++ b/src/routes/learn/add-deck.tsx
@@ -71,7 +71,7 @@ function NewDeckForm() {
 				</Button>
 				{showNewUserUI ?
 					<Link
-						to={`/profile/friend-request`}
+						to={`/friends/request`}
 						className={buttonVariants({ variant: 'link' })}
 					>
 						View friend requests

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -130,8 +130,10 @@ export type FriendshipRow = {
 	updated_at: string
 }
 
-export type FriendRequestAction = Tables<'friend_request_action'>
 export type FriendRequestActionInsert = TablesInsert<'friend_request_action'>
+export type PublicProfileFull = PublicProfile & {
+	friend_summary?: Tables<'friend_summary'>
+}
 
 // for legacy hooks and such
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -11,51 +11,91 @@ export type Database = {
     Tables: {
       friend_request_action: {
         Row: {
-          action_type: Database["public"]["Enums"]["friend_request_action_type"]
+          action_type:
+            | Database["public"]["Enums"]["friend_request_response"]
+            | null
           created_at: string
           id: string
-          uid_from: string
-          uid_to: string
+          uid_by: string
+          uid_for: string
+          uid_less: string | null
+          uid_more: string | null
         }
         Insert: {
-          action_type?: Database["public"]["Enums"]["friend_request_action_type"]
+          action_type?:
+            | Database["public"]["Enums"]["friend_request_response"]
+            | null
           created_at?: string
           id?: string
-          uid_from: string
-          uid_to: string
+          uid_by: string
+          uid_for: string
+          uid_less?: string | null
+          uid_more?: string | null
         }
         Update: {
-          action_type?: Database["public"]["Enums"]["friend_request_action_type"]
+          action_type?:
+            | Database["public"]["Enums"]["friend_request_response"]
+            | null
           created_at?: string
           id?: string
-          uid_from?: string
-          uid_to?: string
+          uid_by?: string
+          uid_for?: string
+          uid_less?: string | null
+          uid_more?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "friend_request_action_uid_from_fkey"
-            columns: ["uid_from"]
+            foreignKeyName: "friend_request_action_uid_by_fkey"
+            columns: ["uid_by"]
             isOneToOne: false
             referencedRelation: "public_profile"
             referencedColumns: ["uid"]
           },
           {
-            foreignKeyName: "friend_request_action_uid_from_fkey"
-            columns: ["uid_from"]
+            foreignKeyName: "friend_request_action_uid_by_fkey"
+            columns: ["uid_by"]
             isOneToOne: false
             referencedRelation: "user_profile"
             referencedColumns: ["uid"]
           },
           {
-            foreignKeyName: "friend_request_action_uid_to_fkey"
-            columns: ["uid_to"]
+            foreignKeyName: "friend_request_action_uid_for_fkey"
+            columns: ["uid_for"]
             isOneToOne: false
             referencedRelation: "public_profile"
             referencedColumns: ["uid"]
           },
           {
-            foreignKeyName: "friend_request_action_uid_to_fkey"
-            columns: ["uid_to"]
+            foreignKeyName: "friend_request_action_uid_for_fkey"
+            columns: ["uid_for"]
+            isOneToOne: false
+            referencedRelation: "user_profile"
+            referencedColumns: ["uid"]
+          },
+          {
+            foreignKeyName: "friend_request_action_uid_less_fkey"
+            columns: ["uid_less"]
+            isOneToOne: false
+            referencedRelation: "public_profile"
+            referencedColumns: ["uid"]
+          },
+          {
+            foreignKeyName: "friend_request_action_uid_less_fkey"
+            columns: ["uid_less"]
+            isOneToOne: false
+            referencedRelation: "user_profile"
+            referencedColumns: ["uid"]
+          },
+          {
+            foreignKeyName: "friend_request_action_uid_more_fkey"
+            columns: ["uid_more"]
+            isOneToOne: false
+            referencedRelation: "public_profile"
+            referencedColumns: ["uid"]
+          },
+          {
+            foreignKeyName: "friend_request_action_uid_more_fkey"
+            columns: ["uid_more"]
             isOneToOne: false
             referencedRelation: "user_profile"
             referencedColumns: ["uid"]
@@ -484,41 +524,71 @@ export type Database = {
       }
     }
     Views: {
-      friend_request_action_recent: {
+      friend_summary: {
         Row: {
-          action_type:
-            | Database["public"]["Enums"]["friend_request_action_type"]
+          most_recent_action_type:
+            | Database["public"]["Enums"]["friend_request_response"]
             | null
-          created_at: string | null
-          id: string | null
-          uid_from: string | null
-          uid_to: string | null
+          most_recent_created_at: string | null
+          most_recent_uid_by: string | null
+          most_recent_uid_for: string | null
+          status: string | null
+          uid_less: string | null
+          uid_more: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "friend_request_action_uid_from_fkey"
-            columns: ["uid_from"]
+            foreignKeyName: "friend_request_action_uid_by_fkey"
+            columns: ["most_recent_uid_by"]
             isOneToOne: false
             referencedRelation: "public_profile"
             referencedColumns: ["uid"]
           },
           {
-            foreignKeyName: "friend_request_action_uid_from_fkey"
-            columns: ["uid_from"]
+            foreignKeyName: "friend_request_action_uid_by_fkey"
+            columns: ["most_recent_uid_by"]
             isOneToOne: false
             referencedRelation: "user_profile"
             referencedColumns: ["uid"]
           },
           {
-            foreignKeyName: "friend_request_action_uid_to_fkey"
-            columns: ["uid_to"]
+            foreignKeyName: "friend_request_action_uid_for_fkey"
+            columns: ["most_recent_uid_for"]
             isOneToOne: false
             referencedRelation: "public_profile"
             referencedColumns: ["uid"]
           },
           {
-            foreignKeyName: "friend_request_action_uid_to_fkey"
-            columns: ["uid_to"]
+            foreignKeyName: "friend_request_action_uid_for_fkey"
+            columns: ["most_recent_uid_for"]
+            isOneToOne: false
+            referencedRelation: "user_profile"
+            referencedColumns: ["uid"]
+          },
+          {
+            foreignKeyName: "friend_request_action_uid_less_fkey"
+            columns: ["uid_less"]
+            isOneToOne: false
+            referencedRelation: "public_profile"
+            referencedColumns: ["uid"]
+          },
+          {
+            foreignKeyName: "friend_request_action_uid_less_fkey"
+            columns: ["uid_less"]
+            isOneToOne: false
+            referencedRelation: "user_profile"
+            referencedColumns: ["uid"]
+          },
+          {
+            foreignKeyName: "friend_request_action_uid_more_fkey"
+            columns: ["uid_more"]
+            isOneToOne: false
+            referencedRelation: "public_profile"
+            referencedColumns: ["uid"]
+          },
+          {
+            foreignKeyName: "friend_request_action_uid_more_fkey"
+            columns: ["uid_more"]
             isOneToOne: false
             referencedRelation: "user_profile"
             referencedColumns: ["uid"]
@@ -774,12 +844,12 @@ export type Database = {
     }
     Enums: {
       card_status: "active" | "learned" | "skipped"
-      friend_request_action_type:
-        | "requested"
-        | "cancelled"
-        | "rejected"
-        | "accepted"
-        | "ended"
+      friend_request_response:
+        | "accept"
+        | "decline"
+        | "cancel"
+        | "remove"
+        | "invite"
       learning_goal: "moving" | "family" | "visiting"
     }
     CompositeTypes: {

--- a/todo.txt
+++ b/todo.txt
@@ -19,6 +19,7 @@ EPIC OF SIGNUPS AND GETTING STARTED AND CONNECTING FRIENDS
 1. ✅ destructive buttons like "unfriend" and "cancel invite" and "decline invitation" should all have dialog confirmations
 
 ISSUES
+1. erroneous link like /learn/undefined should 404, or at least say 'do you wanna start learning this?'
 1. When you try to sign up using existing creds you get an error and then get logged in. We
 	should handle this. (inspect and special-case the error before throwing, and toast accordingly)
 1. Signup workflow should not be a toast-redirect, it should be a success alert, saying go check
@@ -34,6 +35,10 @@ EDGE CASES LEFT BEHIND
 1. If you hack the client it's possible to "Accept" an invitation that hasn't been sent;
 		the RLS can reject these and/or the friend_summary view can check and verify the who sequence.
 		Both of these options seem secure, and they won't conflict.
+1. you can no longer unfriend someone. I would like to build some "info" page/modal or something,
+	just for friends, for the primary purpose of providing this unfriend button, but it would probably 
+	also show	some other info about them. like a profile page. show their decks or something and let
+	you say which ones you'll help with, maybe.
 
 JOURNEYS TO MOCK
 1. Invite a friend (for a learner to invite someone by email)

--- a/todo.txt
+++ b/todo.txt
@@ -12,10 +12,11 @@ EPIC OF SIGNUPS AND GETTING STARTED AND CONNECTING FRIENDS
 	1. ✅ landing page followup steps (/getting-started, etc.)
 	1. implications: there should be someplace in /profile to change this? to "open up" the rest of the app?
 		*	so far, no; the user_role is only used for the getting-started page's redirect
-1. search for friends -- results should include relationship if present
+1. ✅ search for friends -- results should include relationship if present
 	* ✅ this may mean actually the search unit should take an ID and we should fetch the relationship from a map 
 		(so do like how we have deck.pids and and such, with relationships, refactoring this cache entry)
-2. mutation keys for invitations/responses
+1. mutation keys for invitations/responses
+1. destructive buttons like "unfriend" and "cancel invite" and "decline invitation" should all have dialog confirmations
 
 ISSUES
 1. When you try to sign up using existing creds you get an error and then get logged in. We

--- a/todo.txt
+++ b/todo.txt
@@ -15,7 +15,7 @@ EPIC OF SIGNUPS AND GETTING STARTED AND CONNECTING FRIENDS
 1. ✅ search for friends -- results should include relationship if present
 	* ✅ this may mean actually the search unit should take an ID and we should fetch the relationship from a map 
 		(so do like how we have deck.pids and and such, with relationships, refactoring this cache entry)
-1. mutation keys for invitations/responses
+1. ✅ use specific mutation keys for invitations/response actions
 1. destructive buttons like "unfriend" and "cancel invite" and "decline invitation" should all have dialog confirmations
 
 ISSUES

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,4 @@
-EPICS
+EPIC OF SIGNUPS AND GETTING STARTED AND CONNECTING FRIENDS
 1. Got to actually build the signup workflow, for learners and friends
 	1. ✅ add a mock for the form input
 		1. ✅ make the form input look niceeee
@@ -12,6 +12,10 @@ EPICS
 	1. ✅ landing page followup steps (/getting-started, etc.)
 	1. implications: there should be someplace in /profile to change this? to "open up" the rest of the app?
 		*	so far, no; the user_role is only used for the getting-started page's redirect
+1. search for friends -- results should include relationship if present
+	* ✅ this may mean actually the search unit should take an ID and we should fetch the relationship from a map 
+		(so do like how we have deck.pids and and such, with relationships, refactoring this cache entry)
+2. mutation keys for invitations/responses
 
 ISSUES
 1. When you try to sign up using existing creds you get an error and then get logged in. We

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,6 @@
+WHERE I AM NOW:
+We've updated the DB types, but not updates the code accordingly
+
 EPICS
 1. Got to actually build the signup workflow, for learners and friends
 	1. ✅ add a mock for the form input
@@ -8,7 +11,7 @@ EPICS
 		1. ✅ getting-started page just has the username and primary language, creates the profile only.
 		1. _then_ the differentiated page: 
 			*	✅ learners get the add-first-deck page
-			* friends get an accept-friendship page
+			* ✅ friends get an accept-friendship page
 	1. ✅ landing page followup steps (/getting-started, etc.)
 	1. implications: there should be someplace in /profile to change this? to "open up" the rest of the app?
 		*	so far, no; the user_role is only used for the getting-started page's redirect
@@ -20,14 +23,7 @@ ISSUES
 	and verify your email; redirect should happen after this
 1. why is class s-link not working correctly in the "find a friend" search empty results section? (have manually added a border-b, like a barbarian)
 1. accent color isn't working; comes through as light grey; makes the s-link not visible (enough)
-1. Friends data model: we have a problem with stacking multiple invites/requests between the same two people
-	* Solution seems to be a single `friend_relationship` type table that has unique set for the left_uid and right_uid.
-	* then all the actions can have a `friend_relationship_id` and a `friend_action_id`
-	* then some view like `friend_relationship_status_current` can be a view that takes the most recent record from the friend_action table and also calulates another overall status of "no | yes | pending"
-	* then the RLS for the actions can validate inserts based on this "current" status
-		* initial invites can only be sent when overall status is "no" or the relationship is not present
-		* other rules apply as they currently are (but we need to review the setup; and more reason to VC the database, as we put more business logic into it)
-	* the client can respond to RLS mismatches by invalidating the cache only
+1. ✅ Friends data model: we have a problem with stacking multiple invites/requests between the same two people
 
 EDGE CASES LEFT BEHIND
 1. When you reach the getting-started page with no "user role" set
@@ -37,7 +33,7 @@ EDGE CASES LEFT BEHIND
 JOURNEYS TO MOCK
 1. Invite a friend (for a learner to invite someone by email)
 		* invite email for the friend
-		* accept invitation page, account signup form
+		* ✅ accept invitation page, account signup form
 		* landing page for the friend when they sign up... (what can they see?)
 1. ✅ Find a friend screen (for an anon visitor to find a learner)
 		* friend request dialog w signup
@@ -53,13 +49,13 @@ MOCKS / Incompletes
 		we have the component submitting mutations
 1. Invite-A-Friend is a whole feature-set that needs to be built!
 	1. ✅ Accept invite from your friend page is built; the mutation is kind of real and there are success/error states build, 
-		1. We can't really test it yet, till we have actual invites
+		1. ✅ We can't really test it yet, till we have actual invites
 	1. ✅ Search profiles (to invite a friend)
 		1. ✅ Write a mutation to send the friend request, wire up UI states
-			1. This list should become aware of your current friend status with people -- change the button based on whether you've already requested the person, or are friends; (based on server state, not just for the pending mutation or error); 
-				1. Then the mutation can just invalidate the page's queries
-			1. Maybe don't use one mutation: use 1 per item so you can disable just that button and show that isSuccess checkmark icon instead of sharing state across all records. see example: 
-		1. ISBAT see in the search results if I've already requested this person, or if we're already friends, and show that in the UI
+			1. ✅ This list should become aware of your current friend status with people -- change the button based on whether you've already requested the person, or are friends; (based on server state, not just for the pending mutation or error); 
+				1. ✅ Then the mutation can just invalidate the page's queries
+			1. ✅ Maybe don't use one mutation: use 1 per item so you can disable just that button and show that isSuccess checkmark icon instead of sharing state across all records. see example: 
+		1. ✅ ISBAT see in the search results if I've already requested this person, or if we're already friends, and show that in the UI
 		1. ✅ type-as-you-search, debounce it, make sure it's smooth
 	1. Invite a new user (by email) is a separate screen to add (split off from the find-friend route)
 1. ✅ The "Deck Home" screen or Welcome Screen
@@ -78,8 +74,7 @@ MOCKS / Incompletes
 COMPONENTS (ShadCN/Radix)
 1. ✅ Add a Components page to keep track of / showcase all components
 1. ✅ Removing daisyUI
-	1. replace dark:decoration-accent/warning
-	1. disable active link (removed class `disabled`)
+		1. disable active link (removed class `disabled`)
 	1. ✅ 🪲 find-and-fix all these: .page-card .card-white .card .alert
 	1. ✅ fix color codes (text-base) in SelectOneLanguage
 	1. find-replace all these colors: text-base text-base-content etc

--- a/todo.txt
+++ b/todo.txt
@@ -1,5 +1,5 @@
 EPIC OF SIGNUPS AND GETTING STARTED AND CONNECTING FRIENDS
-1. Got to actually build the signup workflow, for learners and friends
+1. ✅ Got to actually build the signup workflow, for learners and friends
 	1. ✅ add a mock for the form input
 		1. ✅ make the form input look niceeee
 	1. ✅ make the form input work
@@ -16,7 +16,7 @@ EPIC OF SIGNUPS AND GETTING STARTED AND CONNECTING FRIENDS
 	* ✅ this may mean actually the search unit should take an ID and we should fetch the relationship from a map 
 		(so do like how we have deck.pids and and such, with relationships, refactoring this cache entry)
 1. ✅ use specific mutation keys for invitations/response actions
-1. destructive buttons like "unfriend" and "cancel invite" and "decline invitation" should all have dialog confirmations
+1. ✅ destructive buttons like "unfriend" and "cancel invite" and "decline invitation" should all have dialog confirmations
 
 ISSUES
 1. When you try to sign up using existing creds you get an error and then get logged in. We

--- a/todo.txt
+++ b/todo.txt
@@ -1,10 +1,7 @@
-WHERE I AM NOW:
-We've updated the DB types, but not updates the code accordingly
-
 EPICS
 1. Got to actually build the signup workflow, for learners and friends
 	1. ✅ add a mock for the form input
-		1. make the form input look niceeee
+		1. ✅ make the form input look niceeee
 	1. ✅ make the form input work
 	1. ~make the signup email nice~
 	1. ✅ differentiate the landing page
@@ -29,6 +26,9 @@ EDGE CASES LEFT BEHIND
 1. When you reach the getting-started page with no "user role" set
 	* rn the redirect pretends you're a helper
 	* we should probably ask ppl instead
+1. If you hack the client it's possible to "Accept" an invitation that hasn't been sent;
+		the RLS can reject these and/or the friend_summary view can check and verify the who sequence.
+		Both of these options seem secure, and they won't conflict.
 
 JOURNEYS TO MOCK
 1. Invite a friend (for a learner to invite someone by email)
@@ -59,7 +59,7 @@ MOCKS / Incompletes
 		1. ✅ type-as-you-search, debounce it, make sure it's smooth
 	1. Invite a new user (by email) is a separate screen to add (split off from the find-friend route)
 1. ✅ The "Deck Home" screen or Welcome Screen
-1. The "new friend signup" screens -- what are we doing here? selecting which deck(s) we're helping with... and then what?
+1. ✅ The "new friend signup" screens -- what are we doing here? selecting which deck(s) we're helping with... and then what?
 	1. How does the friend mode sidebar look? is it the same? are some people Learners _and_ Helpers?
 			(ideally, yes?) should we be switching "modes" like one context switcher that has options for
 			each deck we're learning and each deck we're helping with...
@@ -106,16 +106,17 @@ UI POLISH
 1. When a loader awaits, this is a time to show blank shell and transition in
 
 UPGRADE FORMS
-1. Some existing forms don't use react-hook-form: --- the Getting Started page, the add-deck form.
+1. Some existing forms don't use react-hook-form: -- the add-deck form, for one.
 
 DATA LOADING
 1. ✅ replace useLang with router feature
 1. ✅ replace the old useProfile and ProfileFull
 1. ✅ refresh all the fetcher hooks w the select-paradigm code
-1. don't use `enabled` to waterfall useQueries on auth context
+1. ✅ don't use `enabled` to waterfall useQueries on auth context
 		perhaps this will just be a code convention only render components after auth
 		perhaps there is a better way to use the params / data / keys
-1. Cache structure: we need to be able to retrieve objects by their UUID alone... phrases in particular.
+1. Cache structure: we need to be able to retrieve objects by their UUID alone...
+		phrases in particular. now also relationships or public profiles, bc search results
 
 ROUTER
 1. ✅ if the navbar is not present, use its parent, somehow. (unclear why this is not happening)


### PR DESCRIPTION
This PR should:
- [x] Include updated types from the back-end rework of `friend_request_action` table and `friend_summary` view
- [x] Refactor the search results and the pending requests/invitations sections to use one single component that renders the public profile and whatever buttons are appropriate for the relationship between the user and the person
  - [x] Put the mutations inside these components so each component has an independent loading and success state.
- [x] Use a single cache location for all friendships, and then use selectors for `useFriendInvitations` and `useFriendsInvited`
- [x] Use destructive-style buttons and confirmation dialogs to remove, decline, and cancel friendships and requests
