### PR TITLE
Make the "Invite a friend" page work

### DIFF
--- a/src/routes/_user/friends.invite.tsx
+++ b/src/routes/_user/friends.invite.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Controller, useForm } from 'react-hook-form'
@@ -17,6 +17,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Search, Send } from 'lucide-react'
 import { ShowError } from '@/components/errors'
+import supabase from '@/lib/supabase-client'
 
 export const Route = createFileRoute('/_user/friends/invite')({
 	component: InviteFriendPage,
@@ -39,18 +40,22 @@ function InviteFriendForm() {
 			resolver: zodResolver(inviteFriendSchema),
 		}
 	)
-	const queryClient = useQueryClient()
+	// const queryClient = useQueryClient()
 
 	const invite = useMutation({
 		mutationKey: ['user', 'invite_friend'],
-		mutationFn: async (data: z.infer<typeof inviteFriendSchema>) => {
-			return new Promise((resolve) => setTimeout(() => resolve(data), 1000))
+		mutationFn: async (values: z.infer<typeof inviteFriendSchema>) => {
+			const { data, error } = await supabase.auth.admin.inviteUserByEmail(
+				values.email
+			)
+			if (error) throw error
+			return data
 		},
-		onSuccess: () => {
-			toast.success('Your friend has been invited to help you learn.')
-			void queryClient.invalidateQueries({
+		onSuccess: (_, values) => {
+			toast.success(`Invitation sent to ${values.email}.`)
+			/*void queryClient.invalidateQueries({
 				queryKey: ['user', 'friend_invited'],
-			})
+			})*/
 		},
 	})
 

--- a/src/routes/_user/friends.invite.tsx
+++ b/src/routes/_user/friends.invite.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useMutation } from '@tanstack/react-query'
 import { z } from 'zod'
@@ -5,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { Controller, useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
 
+import { Search, Send } from 'lucide-react'
 import { Button, buttonVariants } from '@/components/ui/button'
 import {
 	Card,
@@ -15,7 +17,6 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Search, Send } from 'lucide-react'
 import { ShowError } from '@/components/errors'
 import supabase from '@/lib/supabase-client'
 
@@ -58,17 +59,25 @@ function InviteFriendPage() {
 
 function NativeShareButton() {
 	const canShare = typeof navigator?.share === 'function'
-	const onClick = async (): Promise<void> => {
+	const [error, setError] = useState<null | DOMException | TypeError>(null)
+	const onClick = (): void => {
 		// console.log('sharing...', navigator, navigator?.canShare())
-		if (navigator?.share) await navigator?.share()
+		if (navigator?.share)
+			navigator
+				?.share({
+					url: `https://sunlo.app/signup`,
+				})
+				.then(() => setError(null))
+				.catch((error: DOMException | TypeError) => setError(error))
 		else console.log(`not sharing bc not possible`)
 	}
 	return (
-		<p>
+		<div>
 			{canShare ?
 				<Button onClick={onClick}>Share</Button>
 			:	<>no sharing options</>}
-		</p>
+			<ShowError>{error?.message}</ShowError>
+		</div>
 	)
 }
 

--- a/src/routes/_user/friends.invite.tsx
+++ b/src/routes/_user/friends.invite.tsx
@@ -63,7 +63,7 @@ function ShareButtons() {
 	const [error, setError] = useState<null | DOMException | TypeError>(null)
 	const { data: profile } = useProfile()
 	const shareData = {
-		url: 'https://sunlo.app/signup',
+		// url: 'https://sunlo.app/signup',
 		text: `Hello friend, I'm learning a language with Sunlo, a social language learning app. Will you join me? https://sunlo.app/signup`,
 		title: `Invitation! ${profile?.username} on Sunlo.app`,
 	}

--- a/src/routes/_user/friends.invite.tsx
+++ b/src/routes/_user/friends.invite.tsx
@@ -26,8 +26,49 @@ export const Route = createFileRoute('/_user/friends/invite')({
 function InviteFriendPage() {
 	return (
 		<main className="flex flex-col gap-6">
-			<InviteFriendForm />
+			<Card>
+				<CardHeader>
+					<CardTitle>
+						<div className="flex flex-row justify-between items-center">
+							<span>Invite a Friend</span>
+							<Link
+								to="/friends/request"
+								aria-disabled="true"
+								className={buttonVariants({
+									size: 'badge',
+									variant: 'outline',
+								})}
+							>
+								<Search className="h-3 w-3" />
+								<span className="me-1">Search </span>
+							</Link>
+						</div>
+					</CardTitle>
+					<CardDescription>
+						Invite a friend to learn with you or to help you learn.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<NativeShareButton />
+				</CardContent>
+			</Card>
 		</main>
+	)
+}
+
+function NativeShareButton() {
+	const canShare = typeof navigator?.share === 'function'
+	const onClick = async (): Promise<void> => {
+		// console.log('sharing...', navigator, navigator?.canShare())
+		if (navigator?.share) await navigator?.share()
+		else console.log(`not sharing bc not possible`)
+	}
+	return (
+		<p>
+			{canShare ?
+				<Button onClick={onClick}>Share</Button>
+			:	<>no sharing options</>}
+		</p>
 	)
 }
 
@@ -64,51 +105,31 @@ function InviteFriendForm() {
 	})
 
 	return (
-		<Card>
-			<CardHeader>
-				<CardTitle>
-					<div className="flex flex-row justify-between items-center">
-						<span>Invite a Friend</span>
-						<Link
-							to="/friends/request"
-							aria-disabled="true"
-							className={buttonVariants({ size: 'badge', variant: 'outline' })}
-						>
-							<Search className="h-3 w-3" />
-							<span className="me-1">Search </span>
-						</Link>
-					</div>
-				</CardTitle>
-				<CardDescription>Send an invitation by email.</CardDescription>
-			</CardHeader>
-			<CardContent>
-				<form onSubmit={onSubmit}>
-					<fieldset
-						className="flex flex-row gap-2 items-end"
-						disabled={invite.isPending}
-					>
-						<div className="w-full">
-							<Label htmlFor="email">Friend's email</Label>
-							<Controller
-								name="email"
-								control={control}
-								render={({ field }) => (
-									<Input
-										{...field}
-										type="email"
-										placeholder="Enter your friend's email"
-									/>
-								)}
+		<form onSubmit={onSubmit}>
+			<fieldset
+				className="flex flex-row gap-2 items-end"
+				disabled={invite.isPending}
+			>
+				<div className="w-full">
+					<Label htmlFor="email">Friend's email</Label>
+					<Controller
+						name="email"
+						control={control}
+						render={({ field }) => (
+							<Input
+								{...field}
+								type="email"
+								placeholder="Enter your friend's email"
 							/>
-						</div>
-						<Button disabled={invite.isPending}>
-							<Send />
-							<span className="hidden @md:block">Send</span>
-						</Button>
-					</fieldset>
-				</form>
-				<ShowError className="mt-4">{invite.error?.message}</ShowError>
-			</CardContent>
-		</Card>
+						)}
+					/>
+				</div>
+				<Button disabled={invite.isPending}>
+					<Send />
+					<span className="hidden @md:block">Send</span>
+				</Button>
+			</fieldset>
+			<ShowError className="mt-4">{invite.error?.message}</ShowError>
+		</form>
 	)
 }


### PR DESCRIPTION
This first commit attempts to use the supabase auth admin API to send an invite email, but it doesn't work. The supabase admin doesn't expose this to any old authenticated user, so I will have to do something else. 

Options include:

1. Use an API route in the repo, to run on Vercel/Cloudflare, not bundled with the native app, to just call [the Postmark API](https://account.postmarkapp.com/servers/14509443/streams/friend-invites/get-started) directly, and then log the invite in the database.
1. Same as option 1 but use a supabase serverless function.
1. Use a link to open up the user's email app :shrug:  also can do Whatsapp and/or the native share dialog... this is, infrastructurally, the easiest one.

Some day we will have to add a back-end to this app, but if we go with option 3, we can say: not today.