### PR TITLE
Refactor the native share button

### DIFF
--- a/src/components/invite-by-email-form.tsx
+++ b/src/components/invite-by-email-form.tsx
@@ -1,0 +1,75 @@
+import { useMutation } from '@tanstack/react-query'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Controller, useForm } from 'react-hook-form'
+import toast from 'react-hot-toast'
+
+import { Send } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ShowError } from '@/components/errors'
+import supabase from '@/lib/supabase-client'
+
+const inviteFriendSchema = z.object({
+	email: z.string().email('Please enter a valid email'),
+})
+
+export function InviteFriendForm() {
+	const { control, handleSubmit } = useForm<z.infer<typeof inviteFriendSchema>>(
+		{
+			resolver: zodResolver(inviteFriendSchema),
+		}
+	)
+	// const queryClient = useQueryClient()
+
+	const invite = useMutation({
+		mutationKey: ['user', 'invite_friend'],
+		mutationFn: async (values: z.infer<typeof inviteFriendSchema>) => {
+			const { data, error } = await supabase.auth.admin.inviteUserByEmail(
+				values.email
+			)
+			if (error) throw error
+			return data
+		},
+		onSuccess: (_, values) => {
+			toast.success(`Invitation sent to ${values.email}.`)
+			/*void queryClient.invalidateQueries({
+				queryKey: ['user', 'friend_invited'],
+			})*/
+		},
+	})
+
+	const onSubmit = handleSubmit((data) => {
+		invite.mutate(data)
+	})
+
+	return (
+		<form onSubmit={onSubmit}>
+			<fieldset
+				className="flex flex-row gap-2 items-end"
+				disabled={invite.isPending}
+			>
+				<div className="w-full">
+					<Label htmlFor="email">Friend's email</Label>
+					<Controller
+						name="email"
+						control={control}
+						render={({ field }) => (
+							<Input
+								{...field}
+								type="email"
+								placeholder="Enter your friend's email"
+							/>
+						)}
+					/>
+				</div>
+				<Button disabled={invite.isPending}>
+					<Send />
+					<span className="hidden @md:block">Send</span>
+				</Button>
+			</fieldset>
+			<ShowError className="mt-4">{invite.error?.message}</ShowError>
+		</form>
+	)
+}

--- a/src/components/native-share-button.tsx
+++ b/src/components/native-share-button.tsx
@@ -1,0 +1,30 @@
+import toast from 'react-hot-toast'
+import { Share } from 'lucide-react'
+import { Button } from './ui/button'
+
+export function NativeShareButton({
+	shareData,
+}: {
+	shareData: { text: string; title: string }
+}) {
+	const canShare = typeof navigator?.share === 'function'
+	if (!canShare) return null
+
+	const onClick = () => {
+		void navigator.share(shareData).catch((error: DOMException | TypeError) => {
+			console.log(
+				`Some error has occurred while sharing. It could just be they cancelled the share.`,
+				error
+			)
+			toast.error(
+				`Some error has occurred while trying to open your device's share screen 🙈 Sorry. Please try something else.`
+			)
+		})
+	}
+
+	return (
+		<Button size="lg" onClick={onClick}>
+			Share <Share />
+		</Button>
+	)
+}

--- a/src/routes/_user/friends.invite.tsx
+++ b/src/routes/_user/friends.invite.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 
-import { Mail, Phone, Search, Share } from 'lucide-react'
-import { Button, buttonVariants } from '@/components/ui/button'
+import { Mail, Phone, Search } from 'lucide-react'
+import { buttonVariants } from '@/components/ui/button'
 import {
 	Card,
 	CardContent,
@@ -10,8 +9,8 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/components/ui/card'
-import { ShowError } from '@/components/errors'
 import { useProfile } from '@/lib/use-profile'
+import { NativeShareButton } from '@/components/native-share-button'
 
 export const Route = createFileRoute('/_user/friends/invite')({
 	component: InviteFriendPage,
@@ -51,43 +50,16 @@ function InviteFriendPage() {
 }
 
 function ShareButtons() {
-	const canShare = typeof navigator?.share === 'function'
-	const [error, setError] = useState<
-		null | DOMException | TypeError | { message: string }
-	>(null)
 	const { data: profile } = useProfile()
 	const shareData = {
 		text: `Hello friend, I'm learning a language with Sunlo, a social language learning app. Will you join me? https://sunlo.app/signup`,
-		title: `Invitation! ${profile?.username} on Sunlo.app`,
+		title: `Invitation! ${profile?.username || 'Join your friend'} on Sunlo.app`,
 	}
-	const onClick = (): void => {
-		// console.log('sharing...', navigator, navigator?.canShare())
-		if (navigator?.share)
-			navigator
-				.share(shareData)
-				.then(() => setError(null))
-				.catch((error: DOMException | TypeError) => {
-					console.log(
-						`Some error has occurred while sharing. It could just be they cancelled the share.`,
-						error
-					)
-					// setError(error)
-				})
-		else {
-			console.log(`not sharing bc not supported`)
-			setError({
-				message: `Sorry, we can't open your device's share interface. Please try one of the other options.`,
-			})
-		}
-	}
+
 	return (
 		<div>
 			<div className="flex flex-col @md:flex-row gap-2">
-				{canShare ?
-					<Button size="lg" onClick={onClick}>
-						Share <Share />
-					</Button>
-				:	null}
+				<NativeShareButton shareData={shareData} />
 				<a
 					className={buttonVariants({ size: 'lg', variant: 'secondary' })}
 					href={`mailto:?subject=${encodeURIComponent(shareData.title)}&body=${encodeURIComponent(shareData.text)}`}
@@ -101,7 +73,6 @@ function ShareButtons() {
 					WhatsApp <Phone className="outline outline-1 rounded-full p-px" />
 				</a>
 			</div>
-			<ShowError>{error?.message}</ShowError>
 		</div>
 	)
 }


### PR DESCRIPTION
There's a bunch of little things bundled up together so it makes sense to pull this into its own file:
* check if canShare or not, return nothing, or return some fallback, if can't share
* share some sharedata with types
* handle errors, provide user feedback